### PR TITLE
Add Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: php
+dist: trusty
+sudo: false
+php:
+  - '5.6'
+  - '7.0'
+  - '7.1'
+  - '7.2'
+  - '7.3'
+  - nightly
+matrix:
+  allow_failures:
+    - php: nightly
+install:
+  - composer install
+script:
+ - ./vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
+        "php": ">=5.6",
         "psr/http-message": "^1.0"
     },
     "require-dev": {
@@ -22,5 +23,10 @@
         "files": [
             "src/functions.php"
         ]
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Http\\Response\\": "tests/"
+        }
     }
 }

--- a/tests/SendTest.php
+++ b/tests/SendTest.php
@@ -3,7 +3,7 @@
 namespace Http\Response;
 
 use phpmock\phpunit\PHPMock;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Psr7\Response;
 
 class SendTest extends TestCase


### PR DESCRIPTION
# Changed log

- Add Travis CI build. The Travis CI build log is available [here](https://travis-ci.org/peter279k/response-sender/builds/495490720).
- Using the class-based PHPUnit namespace to be compatible with the latest stable PHPUnit version.