### PR TITLE
Add compatibility with http-message 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=5.6",
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.0||^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.6",


### PR DESCRIPTION
I love this simple little package and use it frequently, thank you!

All this does is add compatibility with `psr/http-message` version 2.0 or higher to the composer.json file. This library shouldn't require any modifications to function with version 2.0 and adding this compatibility will allow developers to make use of the strong return types in the new version of `psr/http-message`.